### PR TITLE
Added Samsung Galaxy S20 FE 5G

### DIFF
--- a/LIST_OF_DEVICES.txt
+++ b/LIST_OF_DEVICES.txt
@@ -16,6 +16,7 @@
   Xiaomi Redmi K20 Pro                  No
   Xiaomi Redmi Note 4X (Snapdragon)     No
   Xiaomi Redmi 5A                       No
+  Samsung Galaxy S20 FE 5G(Snapdragon)  No
   -------------------------------------------------------------------------------------------------------------------------
   
   


### PR DESCRIPTION
Samsung Galaxy S20 FE 5G have Qcacld-3.0 driver with working monitor mode.